### PR TITLE
feat: Intersection method in rasterize based on geometry type (#20) 🎁 

### DIFF
--- a/semantique/extent.py
+++ b/semantique/extent.py
@@ -188,8 +188,8 @@ class SpatialExtent(dict):
     vector_obj = self._features.reset_index()
     vector_obj["index"] = vector_obj["index"] + 1
     # select intersection method based on the geometry types
-    # We want to use the touch intersection method for Polygons
-    # and Multipolygons
+    # We want to use the intersection of cell centroids if
+    # there are Polygons and Multipolygons, otherwise touch.
     use_centroid_intersection = not any(
       gtype in ["Polygon", "MultiPolygon"] for gtype in vector_obj.geometry.geom_types.values
     )

--- a/semantique/extent.py
+++ b/semantique/extent.py
@@ -146,12 +146,16 @@ class SpatialExtent(dict):
 
     Rasterizing the spatial extent creates a rectangular two-dimensional
     regular grid that covers the bounding box of the extent. Each grid cell
-    corresponds to a spatial location within this bounding box. Cells whose
-    centroid does not intersect with the extent itself gets assigned a value
-    of 0. All other cells get assigned a positive integer, depending on which
+    corresponds to a spatial location within this bounding box. For cells, which
+    does not intersect with the extent itself gets assigned a value of 0. All
+    other cells get assigned a positive integer, depending on which
     of the features in the extent their centroid intersects with, i.e. a 1 if
     it intersects with the first feature in the extent, a 2 if it intersects
     with the second feature in the extent, et cetera.
+    The intersection method that is uses is as follows: If at least one
+    area object is present (Polygons and MultiPolygons) the intersection of the
+    cell centroid is used, otherwise (Multi)Lines and (Multi)Points a touch
+    intersection is used.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Description

This selects the intersection method in the rasterize function based on geometry types. Polygons and MultiPolygons use intersection of pixel centroids, (Multi)Lines and (Multi)Points use touch. Note: If at least one (Multi)LinesPolygon is in there, centroid intersection is used. See the following issue for more details.

Relates to #20 

#### Type of change

Select one or more relevant options:

- [ ] Bug fix (change which fixes a bug reported in a specific issue)
- [x] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
