### PR TITLE
fix: Properties merge in collections :wrench:

### DIFF
--- a/semantique/mapping.py
+++ b/semantique/mapping.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from semantique import exceptions
 from semantique.processor.core import QueryProcessor
 from semantique.processor.arrays import Collection
+from semantique.processor import reducers
 
 class Mapping(dict):
   """Base class for mapping configurations.
@@ -148,7 +149,8 @@ class Semantique(Mapping):
       if len(properties) == 1:
         out = properties[0]
       else:
-        out = Collection(properties).merge("all")
+        func = getattr(reducers, "all_")
+        out = Collection(properties).merge(func)
     else:
       try:
         property = ruleset[property]


### PR DESCRIPTION
#### Description

This fix loads the reducer for the collection creation correctly. In is necessary when entities are defined by several properties that should be evaluated jointly. The changed behaviour with/without fix can be evaluated using the MRE below.

#### Minimum Reproducible Example (MRE)
```
import geopandas as gpd
import json
import semantique as sq
from semantique.processor.utils import parse_extent

# define mapping
# note: the texture attribute isn't meaningful but sufficient for demonstration purposes
mapping = sq.mapping.Semantique()
mapping["entity"] = {}
mapping["entity"]["water"] = {
    "color": sq.appearance("colortype").evaluate("in", [21, 22, 23, 24]),
    "texture": sq.appearance("greenness").evaluate("less", 2)
    }

# define extent
space = sq.SpatialExtent(gpd.read_file("files/footprint.geojson"))
time = sq.TemporalExtent("2019-01-01", "2020-12-31")
extent = parse_extent(space, time, spatial_resolution = [-10, 10], crs = 3035)

# define data cube
with open("files/layout.json", "r") as file:
    dc = sq.datacube.GeotiffArchive(json.load(file), src = "files/layers.zip")

# resolve semantic reference
water = mapping.translate("entity", "water", extent = extent, datacube = dc)

# plot result
levels = [-0.5, 0.5, 1.5]
legend = {"ticks": [0, 1], "label": "is_water"}
colors = ["lightgrey", "deepskyblue"]
water.plot(x = "x", y = "y", col = "time", colors = colors, levels = levels, cbar_kwargs = legend)
```


#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors


