### PR TITLE
fix: consistent dimensions for groupby outputs :wrench:

### DIFF
--- a/semantique/datacube.py
+++ b/semantique/datacube.py
@@ -950,11 +950,15 @@ class STACCube(Datacube):
                 if data.dtype.kind == "f":
                     data = data.where(data != lyr_na)
                     data = (
-                        data.groupby(days).first(skipna=True).rename({"floor": "time"})
+                        data
+                        .groupby(days, squeeze=False)
+                        .first(skipna=True)
+                        .rename({"floor": "time"})
                     )
                 else:
                     data = (
-                        data.groupby(days)
+                        data
+                        .groupby(days, squeeze=False)
                         .reduce(_mosaic_ints, na_value=lyr_na)
                         .rename({"floor": "time"})
                     )

--- a/semantique/processor/arrays.py
+++ b/semantique/processor/arrays.py
@@ -447,7 +447,7 @@ class Array():
     if is_list:
       idx = pd.MultiIndex.from_arrays([x.data for x in grouper])
       dim = grouper[0].dims
-      partition = list(obj.groupby(xr.IndexVariable(dim, idx)))
+      partition = list(obj.groupby(xr.IndexVariable(dim, idx), squeeze=False))
       # Use value labels as group names if defined.
       if labels_as_names:
         labs = [x.sq.value_labels for x in grouper]
@@ -464,7 +464,7 @@ class Array():
       else:
         groups = [i[1].rename(i[0]) for i in partition]
     else:
-      partition = list(obj.groupby(grouper[0]))
+      partition = list(obj.groupby(grouper[0], squeeze=False))
       # Use value labels as group names if defined.
       if labels_as_names:
         labs = grouper[0].sq.value_labels
@@ -1605,7 +1605,7 @@ class Collection(list):
               return Collection(dups).sq.merge(reducers.first_)
             else:
               return obj
-          groups = list(raw.groupby(dimension))
+          groups = list(raw.groupby(dimension, squeeze=False))
           clean = xr.concat([_merge_dups(x[1]) for x in groups], dimension)
         else:
           clean = raw


### PR DESCRIPTION
#### Description

This PR overwrites the default `squeeze=True` for [xarray.groupby()](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.groupby.html) by changing it to False. This ensures that the grouping dimension is always kept in the output arrays. This is important to allow indexing the grouping dimension afterwards in recipes.

#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
