### PR TITLE
fix: keep attrs during reduce :wrench:

### DIFF
--- a/semantique/processor/arrays.py
+++ b/semantique/processor/arrays.py
@@ -493,7 +493,14 @@ class Array():
     out = Collection(groups)
     return out
 
-  def reduce(self, reducer, dimension = None, track_types = True, **kwargs):
+  def reduce(
+      self,
+      reducer,
+      dimension = None,
+      track_types = True,
+      keep_attrs = True,
+      **kwargs
+    ):
     """Apply the reduce verb to the array.
 
     The reduce verb reduces the dimensionality of an array.
@@ -508,6 +515,9 @@ class Array():
       track_types : :obj:`bool`
         Should the reducer promote the value type of the output object, based
         on the value type of the input object?
+      keep_attrs: :obj:`bool`
+        Should the variable's attributes (attrs) be copied from the
+        original object to the new one?
       **kwargs:
         Additional keyword arguments passed on to the reducer function. These
         should not include a keyword argument "dim", which is reserved for
@@ -539,7 +549,7 @@ class Array():
           )
       kwargs["dim"] = dimension
     # Reduce.
-    out = reducer(obj, track_types = track_types, **kwargs)
+    out = reducer(obj, track_types = track_types, keep_attrs = keep_attrs, **kwargs)
     return out
 
   def shift(self, dimension, steps, **kwargs):


### PR DESCRIPTION
#### Description

This PR changes the default during reduce operations to `keep_attrs=True`. In particular, this means that spatial attributes (i.e. ‘spec’, ‘crs’, ‘transform’, ‘resolution’) are retained. In general, their omitting is not critical, as they can be reconstructed using the .rio methods. However, in cases where the arrays contain a spatial dimension with only one pixel width, it is essential to retain the spatial attributes since the spatial information cannot be reconstructed afterwards (-> see [here](https://github.com/corteva/rioxarray/blob/332f4d6e44ddcd47d6569d8a4395b3bb0ca4e1e7/rioxarray/rioxarray.py#L1008)). 

Note that with the basic retention of the attributes, the spatial attributes are also retained for reduce-over-space operations. In my view, however, this is uncritical or even beneficial, as it retains an indication of the original spatial reference frame.

#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
