### PR TITLE
Package name typo fixed - PyStac Client

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,6 @@ dependencies:
   - pip:
     - hvplot
     - planetary-computer
-    - pystack-client
+    - pystac-client
     - stackstac
     - .


### PR DESCRIPTION
Wrong package name 'pystack-client' causing failure in conda environment creation. Fixed to correct one 'pystac-client'.

#### Description

Wrong package name 'pystack-client' causing failure in conda environment creation from `environment.yml`. Fixed by renaming the entry to correct name - 'pystac-client'.

#### Type of change

Select one or more relevant options:

- [ ] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
