### PR TITLE
fix: np.nan compatibility for numpy>=2.0.0 :wrench:

### DIFF
--- a/semantique/datacube.py
+++ b/semantique/datacube.py
@@ -937,7 +937,7 @@ class STACCube(Datacube):
 
         # return extent array as NaN in case of no data
         if not len(item_coll):
-            empty_arr = xr.full_like(extent, np.NaN)
+            empty_arr = xr.full_like(extent, np.nan)
             return empty_arr
 
         # reauth


### PR DESCRIPTION
#### Description

Numpy version 2 requires `np.nan` instead of `np.NaN`.

#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
